### PR TITLE
Update .golangci.yml configuration for improved linting and formatting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,19 @@
+version: "2"
 run:
   tests: true
-  timeout: 15m
-  sort-results: true
   allow-parallel-runners: true
-  exclude-dir: testutil/testdata
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - canonicalheader
     - copyloopvar
-    - errcheck
     - dogsled
+    - errcheck
+    - gocheckcompilerdirectives
     - goconst
     - gocritic
-    - gci
-    - gocheckcompilerdirectives
-    - gofumpt
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - maintidx
@@ -28,96 +22,109 @@ linters:
     - nestif
     - nilerr
     - nolintlint
-    - staticcheck
-    - revive
-    - stylecheck
-    - usetesting
-    - typecheck
-    - tagalign
-    #    - tagliatelle
-    - thelper # too many positives with table tests that have custom setup(*testing.T)
-    - testifylint
-    - perfsprint #
+    - perfsprint
     - promlinter
     - protogetter
+    - revive
+    - staticcheck
+    - tagalign
+    - testifylint
+    - thelper
     - unconvert
-    - unused
     - unparam
+    - unused
     - usestdlibvars
+    - usetesting
     - zerologlint
-
+  settings:
+    dogsled:
+      max-blank-identifiers: 6
+    gosec:
+      includes:
+        - G102
+        - G103
+        - G104
+        - G106
+        - G107
+        - G108
+        - G109
+        - G110
+        - G111
+        - G112
+        - G113
+        - G114
+        - G201
+        - G202
+        - G203
+        - G204
+        - G301
+        - G302
+        - G303
+        - G304
+        - G305
+        - G306
+        - G307
+        - G401
+        - G402
+        - G403
+        - G404
+        - G501
+        - G502
+        - G503
+        - G504
+        - G505
+        - G601
+    misspell:
+      locale: US
+    nolintlint:
+      require-explanation: false
+      require-specific: false
+      allow-unused: false
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - server/grpc/gogoreflection/fix_registration.go
+      - x/wasm/migrations/v2/legacy_types.go
+      - .*\.pb\.go$
+      - .*\.pb\.gw\.\.go$
+      - .*\.pulsar\.go$
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-files:
-    - server/grpc/gogoreflection/fix_registration.go
-    - x/wasm/migrations/v2/legacy_types.go
-    - ".*\\.pb\\.go$"
-    - ".*\\.pb\\.gw\\.\\.go$"
-    - ".*\\.pulsar\\.go$"
-
   max-issues-per-linter: 10000
   max-same-issues: 10000
-
-linters-settings:
-  gci:
-    custom-order: true
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(cosmossdk.io)
-      - prefix(github.com/cosmos/cosmos-sdk)
-      - prefix(github.com/CosmWasm/wasmd)
-
-  gosec:
-    # To select a subset of rules to run.
-    # Available rules: https://github.com/securego/gosec#available-rules
-    # Default: [] - means include all rules
-    includes:
-      #  - G101 # Look for hard coded credentials
-      - G102 # Bind to all interfaces
-      - G103 # Audit the use of unsafe block
-      - G104 # Audit errors not checked
-      - G106 # Audit the use of ssh.InsecureIgnoreHostKey
-      - G107 # Url provided to HTTP request as taint input
-      - G108 # Profiling endpoint automatically exposed on /debug/pprof
-      - G109 # Potential Integer overflow made by strconv.Atoi result conversion to int16/32
-      - G110 # Potential DoS vulnerability via decompression bomb
-      - G111 # Potential directory traversal
-      - G112 # Potential slowloris attack
-      - G113 # Usage of Rat.SetString in math/big with an overflow (CVE-2022-23772)
-      - G114 # Use of net/http serve function that has no support for setting timeouts
-      - G201 # SQL query construction using format string
-      - G202 # SQL query construction using string concatenation
-      - G203 # Use of unescaped data in HTML templates
-      - G204 # Audit use of command execution
-      - G301 # Poor file permissions used when creating a directory
-      - G302 # Poor file permissions used with chmod
-      - G303 # Creating tempfile using a predictable path
-      - G304 # File path provided as taint input
-      - G305 # File traversal when extracting zip/tar archive
-      - G306 # Poor file permissions used when writing to a new file
-      - G307 # Deferring a method which returns an error
-      - G401 # Detect the usage of DES, RC4, MD5 or SHA1
-      - G402 # Look for bad TLS connection settings
-      - G403 # Ensure minimum RSA key length of 2048 bits
-      - G404 # Insecure random number source (rand)
-      - G501 # Import blocklist: crypto/md5
-      - G502 # Import blocklist: crypto/des
-      - G503 # Import blocklist: crypto/rc4
-      - G504 # Import blocklist: net/http/cgi
-      - G505 # Import blocklist: crypto/sha1
-      - G601 # Implicit memory aliasing of items from a range statement
-  misspell:
-    locale: US
-  gofumpt:
-    extra-rules: true
-  dogsled:
-    max-blank-identifiers: 6
-  maligned:
-    suggest-new: true
-  nolintlint:
-    allow-unused: false
-    allow-leading-space: true
-    require-explanation: false
-    require-specific: false
-  gosimple:
-    checks: ["all"]
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(cosmossdk.io)
+        - prefix(github.com/cosmos/cosmos-sdk)
+        - prefix(github.com/CosmWasm/wasmd)
+      custom-order: true
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - server/grpc/gogoreflection/fix_registration.go
+      - x/wasm/migrations/v2/legacy_types.go
+      - .*\.pb\.go$
+      - .*\.pb\.gw\.\.go$
+      - .*\.pulsar\.go$
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
- Set version to 2 and adjusted linters to enable specific checks.
- Added new settings for dogsled, gosec, misspell, nolintlint, and staticcheck.
- Updated exclusions and formatters for better code quality control.
- Removed deprecated linters and streamlined the configuration for clarity.